### PR TITLE
Diff between 2.0.5 sync points in core repos.

### DIFF
--- a/src/core-setup/dependencies.props
+++ b/src/core-setup/dependencies.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <MicrosoftNETCorePlatformsPackageVersion>2.0.1</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.4.3-servicing-25921-02</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
+    <MicrosoftPrivateCoreFxNETCoreAppPackageVersion>4.4.4-servicing-26018-01</MicrosoftPrivateCoreFxNETCoreAppPackageVersion>
     <MicrosoftPrivateCoreFxUAPPackageVersion>4.4.0-preview3-25526-01</MicrosoftPrivateCoreFxUAPPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>2.0.5</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <NETStandardLibraryPackageVersion>2.0.1</NETStandardLibraryPackageVersion>
@@ -87,11 +87,11 @@
       <ElementName>MicrosoftPrivateCoreFxUAPPackageVersion</ElementName>
       <PackageId>Microsoft.Private.CoreFx.UAP</PackageId>
     </XmlUpdateStep>
-<!--    <XmlUpdateStep Include="CoreClr">
+    <XmlUpdateStep Include="CoreClr">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>MicrosoftNETCoreRuntimeCoreCLRPackageVersion</ElementName>
       <PackageId>Microsoft.NETCore.Runtime.CoreCLR</PackageId>
-    </XmlUpdateStep> -->
+    </XmlUpdateStep>
     <XmlUpdateStep Include="Standard">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>NETStandardLibraryPackageVersion</ElementName>

--- a/src/core-setup/src/sharedFramework/sharedFramework.proj
+++ b/src/core-setup/src/sharedFramework/sharedFramework.proj
@@ -133,11 +133,11 @@
       <TrimPkgsFromDeps Include="microsoft.netcore.dotnethostresolver" />
     </ItemGroup>
     
- <!--   <ProcessSharedFrameworkDeps AssetsFilePath="$(SharedFrameworkAssetsFile)"
+    <ProcessSharedFrameworkDeps AssetsFilePath="$(SharedFrameworkAssetsFile)"
                                 DepsFilePath="$(SharedFrameworkDepsFile)"
                                 PackagesToRemove="@(TrimPkgsFromDeps)"
                                 Runtime="$(RuntimeGraphGeneratorRuntime)"
-                                BuildToolsTaskDir="$(BuildToolsTaskDir)" /> -->
+                                BuildToolsTaskDir="$(BuildToolsTaskDir)" />
   </Target>
 
   <Target Name="RestoreLockedCoreHost">

--- a/src/core-setup/tools-local/tasks/core-setup.tasks.csproj
+++ b/src/core-setup/tools-local/tasks/core-setup.tasks.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.ProjectModel">
-      <Version>4.3.0-rtm-4324</Version>
+      <Version>4.3.0-preview2-4095</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyModel">
       <Version>1.1.1</Version>

--- a/src/corefx/dependencies.props
+++ b/src/corefx/dependencies.props
@@ -100,16 +100,16 @@
       <ElementName>CoreFxExpectedPrerelease</ElementName>
       <BuildInfoName>CoreFx</BuildInfoName>
     </XmlUpdateStep>
-<!--    <XmlUpdateStep Include="CoreFx">
+    <XmlUpdateStep Include="CoreFx">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>MicrosoftNETCorePlatformsPackageVersion</ElementName>
       <PackageId>Microsoft.NETCore.Platforms</PackageId>
-    </XmlUpdateStep> -->
-<!--    <XmlUpdateStep Include="CoreClr">
+    </XmlUpdateStep>
+    <XmlUpdateStep Include="CoreClr">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>MicrosoftNETCoreRuntimeCoreCLRPackageVersion</ElementName>
       <PackageId>Microsoft.NETCore.Runtime.CoreCLR</PackageId>
-    </XmlUpdateStep> -->
+    </XmlUpdateStep>
     <XmlUpdateStep Include="Standard">
       <Path>$(MSBuildThisFileFullPath)</Path>
       <ElementName>NETStandardLibraryPackageVersion</ElementName>


### PR DESCRIPTION
@crummel here are a few diffs I found that I would like to better understand why they exist.

Another issue I notices is that coreclr and corefx no longer have patches but core-setup still has a number of patches in the packages folder. Should those be removed as well?