### PR TITLE
Remove 2.0.1 version of Microsoft.NETCore.Platforms from dummy package list

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -87,7 +87,6 @@
       <DummyPackage Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
       <DummyPackage Include="Microsoft.NETCore.Platforms" Version="2.0.0-preview3-25519-01" />
       <DummyPackage Include="Microsoft.NETCore.Platforms" Version="2.0.0" />
-      <DummyPackage Include="Microsoft.NETCore.Platforms" Version="2.0.1" />
       <DummyPackage Include="Microsoft.NETCore.Targets" Version="1.0.1" />
       <DummyPackage Include="Microsoft.NETCore.Targets" Version="1.0.3" />
       <DummyPackage Include="Microsoft.NETCore.Targets" Version="1.1.0" />


### PR DESCRIPTION
corefx is building this version of the library so we shouldn't be producing a dummy version
of this package.


fixes https://github.com/crummel/source-build-tarball-2.0.5/issues/19